### PR TITLE
mlruns .gitignore setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 /data/TRAIN
 **/__pycache__
 **/.DS_Store
-mlruns/203651764970985176/
-mlruns/models/
+**/mlruns/*
+!**/mlruns/.gitkeep


### PR DESCRIPTION
This merge is to avoid to track mlruns folder without affecting project structure.